### PR TITLE
2779-formulary-parsing-failed(PolicyReporter/requests#2779)

### DIFF
--- a/src/main/java/technology/tabula/Ruling.java
+++ b/src/main/java/technology/tabula/Ruling.java
@@ -45,11 +45,11 @@ public class Ruling extends Line2D.Float {
     }
 
     public boolean vertical() {
-        return this.length() > 0 && Utils.feq(this.x1, this.x2); //diff < ORIENTATION_CHECK_THRESHOLD;
+        return this.length() > 0 && this.y1 != this.y2 && Utils.feq(this.x1, this.x2); //diff < ORIENTATION_CHECK_THRESHOLD;
     }
     
     public boolean horizontal() {
-        return this.length() > 0 && Utils.feq(this.y1, this.y2); //diff < ORIENTATION_CHECK_THRESHOLD;
+        return this.length() > 0 && this.x1 != this.x2 && Utils.feq(this.y1, this.y2); //diff < ORIENTATION_CHECK_THRESHOLD;
     }
     
     public boolean oblique() {


### PR DESCRIPTION
2779-formulary-parsing-failed(PolicyReporter/requests#2779)
- Added check to determine horizontal/vertical lines properly

How I tested it:

On the formulary document attached [3653_191374.pdf](https://github.com/PolicyReporter/tabula-java/files/2367247/3653_191374.pdf) executed the following command in vagrant to reproduce the issue:

~~~
java -jar /usr/local/share/tabulapdf/tabula-java-bpi.jar -p all -l -f JSON /opt/pr/policyr/3653_191374.pdf
~~~

After doing the fix... I created and uploaded the newer version of tabula-java rpm in the utils01 server then ran the command below:
~~~
sudo yum clean expire-cache
sudo yum update tabula-java-bpi

java -jar /usr/local/share/tabulapdf/tabula-java-bpi.jar -p all -l -f JSON /opt/pr/policyr/3653_191374.pdf
~~~

This time it ran without any issue

Miscellaneous note:
Basically the fix is as follows:
The logic that checks whether a line is horizontal or vertical allows for slight deviation. The fix here makes an additional check that if a line is perfectly vertical (i.e. x coordinates match) then no need to take slight deviation into account while determining if the line is vertical and same when checking whether the line is horizontal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/policyreporter/tabula-java/3)
<!-- Reviewable:end -->
